### PR TITLE
sixtracklib/common/particles.h: add update function for delta, add in-place increment accessors

### DIFF
--- a/examples/c99/track_simple_bb_from_python.c
+++ b/examples/c99/track_simple_bb_from_python.c
@@ -34,7 +34,7 @@ int main( int argc, char* argv[] )
     st_Buffer* pb = st_Buffer_new( ( buf_size_t )( 1u << 24u ) );
 
     buf_size_t NUM_PARTICLES                = 2;
-    buf_size_t NUM_TURNS                    = 1.;
+    buf_size_t NUM_TURNS                    = 2;
 
     st_Particles*       particles           = SIXTRL_NULLPTR;
     st_Particles const* input_particles     = SIXTRL_NULLPTR;
@@ -126,8 +126,8 @@ int main( int argc, char* argv[] )
     // Write to file
     st_Buffer_write_to_file(dump, "stlib_dump.bin");
     
-    st_Buffer* test = st_Buffer_new_from_file("stlib_dump.bin");
-    st_Particles_buffer_print(stdout, test);
+    //st_Buffer* test = st_Buffer_new_from_file("stlib_dump.bin");
+    //st_Particles_buffer_print(stdout, test);
 
 
     /* ********************************************************************** */

--- a/python/export_to_cobjects.py
+++ b/python/export_to_cobjects.py
@@ -53,7 +53,12 @@ def line2cobject( line, outfile_name ):
                         frequency=elem.frequency, lag=elem.lag )
                         
         elif elem_type=='BeamBeam4D':
-            data = np.array([23.])
+
+            for mm in ['q_part', 'N_part', 'sigma_x', 'sigma_y', 'beta_s',
+                 'min_sigma_diff', 'Delta_x', 'Delta_y', 'Dpx_sub', 'Dpy_sub', 'enabled']:
+                 print('4D: %s, %s'%(mm, repr(getattr(elem,mm))))
+
+            data = elem.tobuffer()
             e = BeamBeam4D( cbuffer=beam_elements, data=data)
             
         elif elem_type=='BeamBeam6D':

--- a/sixtracklib/common/be_beambeam/be_beambeam6d.h
+++ b/sixtracklib/common/be_beambeam/be_beambeam6d.h
@@ -30,6 +30,20 @@ typedef struct NS(BeamBeam6D)
 }
 NS(BeamBeam6D);
 
+typedef struct{
+    SIXTRL_REAL_T q_part;
+    SIXTRL_REAL_T N_part;
+    SIXTRL_REAL_T sigma_x;
+    SIXTRL_REAL_T sigma_y;
+    SIXTRL_REAL_T beta_s;
+    SIXTRL_REAL_T min_sigma_diff;
+    SIXTRL_REAL_T Delta_x;
+    SIXTRL_REAL_T Delta_y;
+    SIXTRL_REAL_T Dpx_sub;
+    SIXTRL_REAL_T Dpy_sub;
+    SIXTRL_INT64_T enabled;
+}BB4D_data;
+
 
 typedef struct{
     SIXTRL_REAL_T sphi;
@@ -81,6 +95,7 @@ typedef struct{
     SIXTRL_BE_DATAPTR_DEC SIXTRL_REAL_T* y_slices_star;
     SIXTRL_BE_DATAPTR_DEC SIXTRL_REAL_T* sigma_slices_star;
 }BB6D_data;
+
 
 SIXTRL_FN SIXTRL_STATIC  SIXTRL_BE_ARGPTR_DEC NS(BeamBeam6D)*
 NS(BeamBeam6D_preset)(

--- a/sixtracklib/common/be_beambeam/gauss_fields.h
+++ b/sixtracklib/common/be_beambeam/gauss_fields.h
@@ -26,7 +26,7 @@ SIXTRL_FN SIXTRL_STATIC void get_transv_field_gauss_ellip(
 SIXTRL_FN SIXTRL_STATIC void get_Ex_Ey_Gx_Gy_gauss(
     SIXTRL_REAL_T x, SIXTRL_REAL_T  y,
     SIXTRL_REAL_T sigma_x, SIXTRL_REAL_T sigma_y,
-    SIXTRL_REAL_T min_sigma_diff,
+    SIXTRL_REAL_T min_sigma_diff, int skip_Gs,
     SIXTRL_ARGPTR_DEC SIXTRL_REAL_T* Ex_ptr,
     SIXTRL_ARGPTR_DEC SIXTRL_REAL_T* Ey_ptr,
     SIXTRL_ARGPTR_DEC SIXTRL_REAL_T* Gx_ptr,
@@ -151,7 +151,7 @@ SIXTRL_INLINE void get_transv_field_gauss_ellip(
 SIXTRL_INLINE void get_Ex_Ey_Gx_Gy_gauss(
     SIXTRL_REAL_T x, SIXTRL_REAL_T  y,
     SIXTRL_REAL_T sigma_x, SIXTRL_REAL_T sigma_y,
-    SIXTRL_REAL_T min_sigma_diff,
+    SIXTRL_REAL_T min_sigma_diff, int skip_Gs,
     SIXTRL_ARGPTR_DEC SIXTRL_REAL_T* Ex_ptr,
     SIXTRL_ARGPTR_DEC SIXTRL_REAL_T* Ey_ptr,
     SIXTRL_ARGPTR_DEC SIXTRL_REAL_T* Gx_ptr,
@@ -165,10 +165,17 @@ SIXTRL_INLINE void get_Ex_Ey_Gx_Gy_gauss(
 
         get_transv_field_gauss_round(sigma, 0., 0., x, y, &Ex, &Ey);
 
-        Gx = 1/(2.*(x*x+y*y))*(y*Ey-x*Ex+1./(2*MYPI*EPSILON_0*sigma*sigma)
+        if(skip_Gs){
+          Gx = 0.;
+          Gy = 0.;
+        }
+        else{
+          Gx = 1/(2.*(x*x+y*y))*(y*Ey-x*Ex+1./(2*MYPI*EPSILON_0*sigma*sigma)
                             *x*x*exp(-(x*x+y*y)/(2.*sigma*sigma)));
-        Gy = 1./(2*(x*x+y*y))*(x*Ex-y*Ey+1./(2*MYPI*EPSILON_0*sigma*sigma)
+          Gy = 1./(2*(x*x+y*y))*(x*Ex-y*Ey+1./(2*MYPI*EPSILON_0*sigma*sigma)
                             *y*y*exp(-(x*x+y*y)/(2.*sigma*sigma)));
+        }
+        
     }
     else{
 
@@ -177,10 +184,17 @@ SIXTRL_INLINE void get_Ex_Ey_Gx_Gy_gauss(
         SIXTRL_REAL_T Sig_11 = sigma_x*sigma_x;
         SIXTRL_REAL_T Sig_33 = sigma_y*sigma_y;
 
-        Gx =-1./(2*(Sig_11-Sig_33))*(x*Ex+y*Ey+1./(2*MYPI*EPSILON_0)*\
-                    (sigma_y/sigma_x*exp(-x*x/(2*Sig_11)-y*y/(2*Sig_33))-1.));
-        Gy =1./(2*(Sig_11-Sig_33))*(x*Ex+y*Ey+1./(2*MYPI*EPSILON_0)*\
-                    (sigma_x/sigma_y*exp(-x*x/(2*Sig_11)-y*y/(2*Sig_33))-1.));
+        if(skip_Gs){
+          Gx = 0.;
+          Gy = 0.;
+        }
+        else{
+          Gx =-1./(2*(Sig_11-Sig_33))*(x*Ex+y*Ey+1./(2*MYPI*EPSILON_0)*\
+                      (sigma_y/sigma_x*exp(-x*x/(2*Sig_11)-y*y/(2*Sig_33))-1.));
+          Gy =1./(2*(Sig_11-Sig_33))*(x*Ex+y*Ey+1./(2*MYPI*EPSILON_0)*\
+                      (sigma_x/sigma_y*exp(-x*x/(2*Sig_11)-y*y/(2*Sig_33))-1.));
+        }
+
     }
 
     *Ex_ptr = Ex;

--- a/sixtracklib/common/be_beambeam/track_beambeam.h
+++ b/sixtracklib/common/be_beambeam/track_beambeam.h
@@ -63,10 +63,28 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_4d)(
     SIXTRL_TRACK_RETURN ret = 0;
 
     typedef NS(beambeam4d_real_const_ptr_t)  bb_data_ptr_t;
+    //typedef SIXTRL_UINT64_T u64_t;
+    //typedef SIXTRL_REAL_T real_t;
+    typedef SIXTRL_BE_DATAPTR_DEC BB4D_data* BB4D_data_ptr_t;
 
-    SIXTRL_UINT64_T const data_size = NS(BeamBeam4D_get_data_size)( bb );
     bb_data_ptr_t data = NS(BeamBeam4D_get_const_data)( bb );
-    (void) data_size; // just to avoid error: unused variable
+
+    BB4D_data_ptr_t bb4ddata = (BB4D_data_ptr_t) data;
+
+    printf("4D: q_part = %e\n",bb4ddata->q_part);
+    printf("4D: N_part = %e\n",bb4ddata->N_part);
+    printf("4D: sigma_x = %e\n",bb4ddata->sigma_x);
+    printf("4D: sigma_y = %e\n",bb4ddata->sigma_y);
+    printf("4D: beta_s = %e\n",bb4ddata->beta_s);
+    printf("4D: min_sigma_diff = %e\n",bb4ddata->min_sigma_diff);
+    printf("4D: Delta_x = %e\n",bb4ddata->Delta_x);
+    printf("4D: Delta_y = %e\n",bb4ddata->Delta_y);
+    printf("4D: Dpx_sub = %e\n",bb4ddata->Dpx_sub);
+    printf("4D: Dpy_sub = %e\n",bb4ddata->Dpy_sub);
+    printf("4D: enabled = %ld\n",bb4ddata->enabled);
+
+
+
 
     SIXTRL_REAL_T x = NS(Particles_get_x_value)( particles, particle_index );
     x += ( SIXTRL_REAL_T )0.0 + 0.*data[0];

--- a/sixtracklib/common/be_beambeam/track_beambeam.h
+++ b/sixtracklib/common/be_beambeam/track_beambeam.h
@@ -93,7 +93,6 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_4d)(
         real_t py = NS(Particles_get_py_value)( particles, particle_index );
 
         real_t qratio = 1.;// To be generalized for multi-ion!
-
         real_t charge = qratio*NS(Particles_get_q0_value)( particles, particle_index )*QELEM;
         
         real_t x = NS(Particles_get_x_value)( particles, particle_index ) - bb4ddata->Delta_x;

--- a/sixtracklib/common/be_beambeam/track_beambeam.h
+++ b/sixtracklib/common/be_beambeam/track_beambeam.h
@@ -107,7 +107,7 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_4d)(
 
         real_t Ex, Ey, Gx, Gy;
         get_Ex_Ey_Gx_Gy_gauss(x, y, bb4ddata->sigma_x, bb4ddata->sigma_y,
-                bb4ddata->min_sigma_diff,
+                bb4ddata->min_sigma_diff, 1, 
                 &Ex, &Ey, &Gx, &Gy);
 
         real_t fact_kick = chi * bb4ddata->N_part * bb4ddata->q_part * charge * \
@@ -236,7 +236,7 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_6d)(
             // Get transverse fieds
             real_t Ex, Ey, Gx, Gy;
             get_Ex_Ey_Gx_Gy_gauss(x_bar_hat_star, y_bar_hat_star, 
-                sqrt(Sig_11_hat_star), sqrt(Sig_33_hat_star), bb6ddata->min_sigma_diff,
+                sqrt(Sig_11_hat_star), sqrt(Sig_33_hat_star), bb6ddata->min_sigma_diff, 0,
                 &Ex, &Ey, &Gx, &Gy);
                 
             // Compute kicks

--- a/sixtracklib/common/be_beambeam/track_beambeam.h
+++ b/sixtracklib/common/be_beambeam/track_beambeam.h
@@ -4,7 +4,7 @@
 #ifndef SIXTRL_BB6_GET_PTR
 	#define SIXTRL_BB_GET_PTR(dataptr,name) \
 		 (SIXTRL_BE_DATAPTR_DEC real_t*)(((SIXTRL_BE_DATAPTR_DEC u64_t*) (&((dataptr)->name))) \
-		 	+ ((u64_t) (dataptr)->name) + 1)    
+		 	+ ((u64_t) (dataptr)->name) + 1)
 #endif
 
 #if !defined( SIXTRL_NO_INCLUDES )
@@ -94,7 +94,7 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_4d)(
 
         real_t qratio = 1.;// To be generalized for multi-ion!
         real_t charge = qratio*NS(Particles_get_q0_value)( particles, particle_index )*QELEM;
-        
+
         real_t x = NS(Particles_get_x_value)( particles, particle_index ) - bb4ddata->Delta_x;
         real_t y = NS(Particles_get_y_value)( particles, particle_index ) - bb4ddata->Delta_y;
 
@@ -106,7 +106,7 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_4d)(
 
         real_t Ex, Ey, Gx, Gy;
         get_Ex_Ey_Gx_Gy_gauss(x, y, bb4ddata->sigma_x, bb4ddata->sigma_y,
-                bb4ddata->min_sigma_diff, 1, 
+                bb4ddata->min_sigma_diff, 1,
                 &Ex, &Ey, &Gx, &Gy);
 
         real_t fact_kick = chi * bb4ddata->N_part * bb4ddata->q_part * charge * \
@@ -160,14 +160,14 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_6d)(
         printf("calpha=%e\n",(bb6ddata->parboost).calpha);
         printf("S33=%e\n",(bb6ddata->Sigmas_0_star).Sig_33_0);
         printf("N_slices=%d\n",N_slices);
-        printf("N_part_per_slice[0]=%e\n",N_part_per_slice[0]); 
-        printf("N_part_per_slice[1]=%e\n",N_part_per_slice[1]); 
-        printf("x_slices_star[0]=%e\n",x_slices_star[0]); 
-        printf("x_slices_star[1]=%e\n",x_slices_star[1]); 
-        printf("y_slices_star[0]=%e\n",y_slices_star[0]); 
-        printf("y_slices_star[1]=%e\n",y_slices_star[1]);         
-        printf("sigma_slices_star[0]=%e\n",sigma_slices_star[0]); 
-        printf("sigma_slices_star[1]=%e\n",sigma_slices_star[1]); 
+        printf("N_part_per_slice[0]=%e\n",N_part_per_slice[0]);
+        printf("N_part_per_slice[1]=%e\n",N_part_per_slice[1]);
+        printf("x_slices_star[0]=%e\n",x_slices_star[0]);
+        printf("x_slices_star[1]=%e\n",x_slices_star[1]);
+        printf("y_slices_star[0]=%e\n",y_slices_star[0]);
+        printf("y_slices_star[1]=%e\n",y_slices_star[1]);
+        printf("sigma_slices_star[0]=%e\n",sigma_slices_star[0]);
+        printf("sigma_slices_star[1]=%e\n",sigma_slices_star[1]);
         */
 
         real_t x = NS(Particles_get_x_value)( particles, particle_index );
@@ -191,7 +191,7 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_6d)(
         real_t delta_star = delta - bb6ddata->delta_CO;
 
         // Boost coordinates of the weak beam
-        BB6D_boost(&(bb6ddata->parboost), &x_star, &px_star, &y_star, &py_star, 
+        BB6D_boost(&(bb6ddata->parboost), &x_star, &px_star, &y_star, &py_star,
                     &sigma_star, &delta_star);
 
 
@@ -201,57 +201,57 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_6d)(
             real_t sigma_slice_star = sigma_slices_star[i_slice];
             real_t x_slice_star = x_slices_star[i_slice];
             real_t y_slice_star = y_slices_star[i_slice];
-            
+
             //Compute force scaling factor
             real_t Ksl = N_part_per_slice[i_slice]*bb6ddata->q_part*q0/(P0*C_LIGHT);
 
             //Identify the Collision Point (CP)
             real_t S = 0.5*(sigma_star - sigma_slice_star);
-            
+
             // Propagate sigma matrix
             real_t Sig_11_hat_star, Sig_33_hat_star, costheta, sintheta;
             real_t dS_Sig_11_hat_star, dS_Sig_33_hat_star, dS_costheta, dS_sintheta;
-            
+
             // Get strong beam shape at the CP
             BB6D_propagate_Sigma_matrix(&(bb6ddata->Sigmas_0_star),
                 S, bb6ddata->threshold_singular, 1,
-                &Sig_11_hat_star, &Sig_33_hat_star, 
+                &Sig_11_hat_star, &Sig_33_hat_star,
                 &costheta, &sintheta,
-                &dS_Sig_11_hat_star, &dS_Sig_33_hat_star, 
+                &dS_Sig_11_hat_star, &dS_Sig_33_hat_star,
                 &dS_costheta, &dS_sintheta);
-                
+
             // Evaluate transverse coordinates of the weake baem w.r.t. the strong beam centroid
             real_t x_bar_star = x_star + px_star*S - x_slice_star;
             real_t y_bar_star = y_star + py_star*S - y_slice_star;
-            
+
             // Move to the uncoupled reference frame
             real_t x_bar_hat_star = x_bar_star*costheta +y_bar_star*sintheta;
             real_t y_bar_hat_star = -x_bar_star*sintheta +y_bar_star*costheta;
-            
+
             // Compute derivatives of the transformation
             real_t dS_x_bar_hat_star = x_bar_star*dS_costheta +y_bar_star*dS_sintheta;
             real_t dS_y_bar_hat_star = -x_bar_star*dS_sintheta +y_bar_star*dS_costheta;
-            
+
             // Get transverse fieds
             real_t Ex, Ey, Gx, Gy;
-            get_Ex_Ey_Gx_Gy_gauss(x_bar_hat_star, y_bar_hat_star, 
+            get_Ex_Ey_Gx_Gy_gauss(x_bar_hat_star, y_bar_hat_star,
                 sqrt(Sig_11_hat_star), sqrt(Sig_33_hat_star), bb6ddata->min_sigma_diff, 0,
                 &Ex, &Ey, &Gx, &Gy);
-                
+
             // Compute kicks
             real_t Fx_hat_star = Ksl*Ex;
             real_t Fy_hat_star = Ksl*Ey;
             real_t Gx_hat_star = Ksl*Gx;
             real_t Gy_hat_star = Ksl*Gy;
-            
+
             // Move kisks to coupled reference frame
             real_t Fx_star = Fx_hat_star*costheta - Fy_hat_star*sintheta;
             real_t Fy_star = Fx_hat_star*sintheta + Fy_hat_star*costheta;
-            
+
             // Compute longitudinal kick
             real_t Fz_star = 0.5*(Fx_hat_star*dS_x_bar_hat_star  + Fy_hat_star*dS_y_bar_hat_star+
                            Gx_hat_star*dS_Sig_11_hat_star + Gy_hat_star*dS_Sig_33_hat_star);
-                           
+
             // Apply the kicks (Hirata's synchro-beam)
             delta_star = delta_star + Fz_star+0.5*(
                         Fx_star*(px_star+0.5*Fx_star)+
@@ -260,14 +260,14 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_6d)(
             px_star = px_star + Fx_star;
             y_star = y_star - S*Fy_star;
             py_star = py_star + Fy_star;
-            
+
 
         }
 
         // Inverse boost on the coordinates of the weak beam
-        BB6D_inv_boost(&(bb6ddata->parboost), &x_star, &px_star, &y_star, &py_star, 
+        BB6D_inv_boost(&(bb6ddata->parboost), &x_star, &px_star, &y_star, &py_star,
                     &sigma_star, &delta_star);
-                    
+
 
         // Go back to original reference frame and remove dipolar effect
         x =     x_star     + bb6ddata->x_CO   + bb6ddata->delta_x  - bb6ddata->Dx_sub;
@@ -283,27 +283,9 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_6d)(
         NS(Particles_set_y_value)( particles, particle_index, y );
         NS(Particles_set_py_value)( particles, particle_index, py );
         NS(Particles_set_zeta_value)( particles, particle_index, zeta );
-        NS(Particles_set_delta_value)( particles, particle_index,delta );
-
-        /////// To be reaplced with update deltas
-        real_t beta0 = NS(Particles_get_beta0_value)( particles, particle_index );
-
-        real_t deltabeta0 = delta*beta0;
-        real_t ptaubeta0 = sqrt(deltabeta0*deltabeta0+2*deltabeta0*beta0 + 1)-1;
-        real_t rvv  = (1+delta)/(1+ptaubeta0);
-        real_t rpp = 1./(delta+1.);
-        real_t psigma = ptaubeta0/(beta0*beta0);
-
-        
-        NS(Particles_set_psigma_value)( particles, particle_index, psigma );
-        NS(Particles_set_rpp_value)( particles, particle_index, rpp );
-        NS(Particles_set_rvv_value)( particles, particle_index, rvv );
-        ////////
-
-        
-
+        NS(Particles_update_delta_value)( particles, particle_index, delta );
     }
-    
+
 
     return ret;
 }
@@ -311,5 +293,5 @@ SIXTRL_INLINE SIXTRL_TRACK_RETURN NS(Track_particle_beam_beam_6d)(
 #if !defined( _GPUCODE ) && defined( __cplusplus )
 }
 #endif /* !defined(  _GPUCODE ) && defined( __cplusplus ) */
-#endif 
+#endif
 /* end: sixtracklib/common/be_beambeam/track_beambeam.h */

--- a/sixtracklib/common/buffer.h
+++ b/sixtracklib/common/buffer.h
@@ -6,7 +6,6 @@
     #include <stddef.h>
     #include <stdint.h>
     #include <stdlib.h>
-    #include <stdio.h>
     #include <limits.h>
 #endif /* !defined( SIXTRL_NO_SYSTEM_INCLUDES ) */
 
@@ -186,6 +185,10 @@ SIXTRL_FN SIXTRL_STATIC int NS(Buffer_reserve)(
     NS(buffer_size_t) const new_max_num_dataptrs,
     NS(buffer_size_t) const new_max_num_garbage_ranges );
 
+SIXTRL_FN SIXTRL_STATIC int NS(Buffer_reserve_capacity)(
+    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
+    NS(buffer_size_t) const new_buffer_capacity );
+
 SIXTRL_FN SIXTRL_STATIC bool NS(Buffer_needs_remapping)(
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT buffer );
 
@@ -200,15 +203,19 @@ SIXTRL_HOST_FN SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* NS(Buffer_new)(
     NS(buffer_size_t) const buffer_capacity );
 
 SIXTRL_HOST_FN SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* NS(Buffer_new_from_file)(
-    SIXTRL_BUFFER_ARGPTR_DEC char const* SIXTRL_RESTRICT path_to_file );
+    SIXTRL_ARGPTR_DEC char const* SIXTRL_RESTRICT path_to_file );
+
+SIXTRL_HOST_FN bool NS(Buffer_read_from_file)(
+    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
+    SIXTRL_ARGPTR_DEC char const* SIXTRL_RESTRICT path_to_file );
 
 SIXTRL_HOST_FN bool NS(Buffer_write_to_file)(
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT buffer,
-    SIXTRL_BUFFER_ARGPTR_DEC char const* SIXTRL_RESTRICT path_to_file );
+    SIXTRL_ARGPTR_DEC char const* SIXTRL_RESTRICT path_to_file );
 
 SIXTRL_HOST_FN bool NS(Buffer_write_to_fp)(
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT buffer,
-    FILE* SIXTRL_RESTRICT fp );
+    SIXTRL_ARGPTR_DEC FILE* SIXTRL_RESTRICT fp );
 
 SIXTRL_HOST_FN SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* NS(Buffer_new_detailed)(
     NS(buffer_size_t)  const initial_max_num_objects,
@@ -284,7 +291,10 @@ SIXTRL_FN SIXTRL_STATIC SIXTRL_BUFFER_DATAPTR_DEC NS(Object)*
 /* For plain C/Cxx */
 
 #if !defined( SIXTRL_NO_SYSTEM_INCLUDES )
-    #include <stdio.h>
+    #if !defined( _GPUCODE )
+        #include <stdio.h>
+        #include <string.h>
+    #endif /* !defined( _GPUCODE ) */
 #endif /* !defined( SIXTRL_NO_SYSTEM_INCLUDES ) */
 
 #if !defined( SIXTRL_NO_INCLUDES)
@@ -901,6 +911,48 @@ SIXTRL_INLINE int NS(Buffer_reserve)(
         {
             success = NS(Buffer_reserve_generic)( buffer, max_num_objects,
                 max_num_slots, max_num_dataptrs, max_num_garbage_ranges );
+        }
+    }
+
+    return success;
+}
+
+SIXTRL_INLINE int NS(Buffer_reserve_capacity)(
+    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
+    NS(buffer_size_t) const new_buffer_capacity )
+{
+    int success = -1;
+
+    if( ( NS(Buffer_uses_datastore)( buffer ) ) &&
+        ( NS(Buffer_allow_resize)( buffer ) ) )
+    {
+        /*
+        #if defined( SIXTRACKLIB_ENABLE_MODULE_OPENCL ) && \
+             SIXTRACKLIB_ENABLE_MODULE_OPENCL == 1
+
+        if( NS(Buffer_uses_special_opencl_datastore)( buffer ) )
+        {
+            success = NS(Buffer_reserve_capacity_opencl)(
+                buffer, new_buffer_capacity );
+        }
+        else
+        #endif *//* SIXTRACKLIB_ENABLE_MODULE_OPENCL */
+
+        /*
+        #if defined( SIXTRACKLIB_ENABLE_MODULE_CUDA ) && \
+             SIXTRACKLIB_ENABLE_MODULE_CUDA == 1
+
+        if( NS(Buffer_uses_special_cuda_datastore)( buffer ) )
+        {
+            success = NS(Buffer_reserve_capacity_cuda)(
+                buffer, new_buffer_capacity );
+        }
+        else
+        #endif */ /* SIXTRACKLIB_ENABLE_MODULE_CUDA */
+
+        {
+            success = NS(Buffer_reserve_capacity_generic)(
+                buffer, new_buffer_capacity );
         }
     }
 

--- a/sixtracklib/common/buffer.hpp
+++ b/sixtracklib/common/buffer.hpp
@@ -6,8 +6,10 @@
         #include <cstddef>
         #include <cstdint>
         #include <cstdlib>
+        #include <cstdio>
         #include <limits>
         #include <utility>
+        #include <string>
     #endif /* defined( __cplusplus ) */
 #endif /* !defined( SIXTRL_NO_SYSTEM_INCLUDES ) */
 
@@ -69,6 +71,11 @@ namespace SIXTRL_NAMESPACE
             size_type max_num_garbage_ranges,
             size_type buffer_capacity ) SIXTRL_NOEXCEPT;
 
+        #if !defined( GPUCODE )
+        SIXTRL_HOST_FN Buffer( char const* path_to_file );
+        SIXTRL_HOST_FN Buffer( std::string const& path_to_file );
+        #endif /* !defined( GPUCODE ) */
+
         /* TODO: Implement Copy & Move semantics for Buffer */
         SIXTRL_FN Buffer( Buffer const& other ) = delete;
         SIXTRL_FN Buffer( Buffer&& other ) = delete;
@@ -124,30 +131,34 @@ namespace SIXTRL_NAMESPACE
 
         /* ----------------------------------------------------------------- */
 
-        SIXTRL_FN size_type size()                  const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type capacity()              const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type headerSize()            const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type size()                   const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type capacity()               const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type headerSize()             const SIXTRL_NOEXCEPT;
 
-        SIXTRL_FN size_type getSize()               const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type getCapacity()           const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getSize()                const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getCapacity()            const SIXTRL_NOEXCEPT;
 
-        SIXTRL_FN size_type getSlotSize()           const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type getHeaderSize()         const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type getSectionHeaderSize()  const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getSlotSize()            const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getHeaderSize()          const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getSectionHeaderSize()   const SIXTRL_NOEXCEPT;
 
         /* ----------------------------------------------------------------- */
 
-        SIXTRL_FN size_type getNumSlots()           const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type getMaxNumSlots()        const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type getSlotsSize()          const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getNumSlots()            const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getMaxNumSlots()         const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getSlotsSize()           const SIXTRL_NOEXCEPT;
 
-        SIXTRL_FN size_type getNumObjects()         const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type getMaxNumObjects()      const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type getObjectsSize()        const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getNumObjects()          const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getMaxNumObjects()       const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getObjectsSize()         const SIXTRL_NOEXCEPT;
 
-        SIXTRL_FN size_type getNumDataptrs()        const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type getMaxNumDataptrs()     const SIXTRL_NOEXCEPT;
-        SIXTRL_FN size_type getDataptrsSize()       const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getNumDataptrs()         const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getMaxNumDataptrs()      const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getDataptrsSize()        const SIXTRL_NOEXCEPT;
+
+        SIXTRL_FN size_type getNumGarbageRanges()    const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getMaxNumGarbageRanges() const SIXTRL_NOEXCEPT;
+        SIXTRL_FN size_type getGarbageRangesSize()   const SIXTRL_NOEXCEPT;
 
         /* ----------------------------------------------------------------- */
 
@@ -224,6 +235,13 @@ namespace SIXTRL_NAMESPACE
             Ptr SIXTRL_RESTRICT counts );
 
         private:
+
+        #if !defined( _GPUCODE )
+
+        SIXTRL_HOST_FN SIXTRL_STATIC size_type GetBinaryFileSize(
+            char const* path_to_file ) SIXTRL_NOEXCEPT;
+
+        #endif /* !defined( _GPUCODE ) */
 
         bool allocateDataStore(
             size_type const buffer_capacity, flags_t const flags );
@@ -351,6 +369,50 @@ namespace SIXTRL_NAMESPACE
             ::NS(Buffer_free)( _buffer );
         }
     }
+
+    #if !defined( GPUCODE )
+    SIXTRL_INLINE Buffer::Buffer( char const* path_to_file ) : ::NS(Buffer)()
+    {
+        using c_api_t = Buffer::c_api_t;
+        using size_t  = Buffer::size_type;
+
+        size_t const required_buffer_size =
+            Buffer::GetBinaryFileSize( path_to_file );
+
+        c_api_t* _buffer = ::NS(Buffer_preset)( this->getCApiPtr() );
+
+        if( this->allocateDataStore( required_buffer_size,
+                                     Buffer::DEFAULT_DATASTORE_FLAGS ) )
+        {
+            ::NS(Buffer_read_from_file)( _buffer, path_to_file );
+        }
+        else
+        {
+            ::NS(Buffer_free)( _buffer );
+        }
+    }
+
+    SIXTRL_INLINE Buffer::Buffer( std::string const& path_to_file ) : ::NS(Buffer)()
+    {
+        using c_api_t = Buffer::c_api_t;
+        using size_t  = Buffer::size_type;
+
+        size_t const required_buffer_size =
+            Buffer::GetBinaryFileSize( path_to_file.c_str() );
+
+        c_api_t* _buffer = ::NS(Buffer_preset)( this->getCApiPtr() );
+
+        if( this->allocateDataStore( required_buffer_size,
+                                     Buffer::DEFAULT_DATASTORE_FLAGS ) )
+        {
+            ::NS(Buffer_read_from_file)( _buffer, path_to_file.c_str() );
+        }
+        else
+        {
+            ::NS(Buffer_free)( _buffer );
+        }
+    }
+    #endif /* !defined( _GPUCODE ) */
 
     SIXTRL_INLINE Buffer::~Buffer()
     {
@@ -623,6 +685,26 @@ namespace SIXTRL_NAMESPACE
         return NS(Buffer_get_dataptrs_size)( this->getCApiPtr() );
     }
 
+
+
+    SIXTRL_INLINE Buffer::size_type
+    Buffer::getNumGarbageRanges() const SIXTRL_NOEXCEPT
+    {
+        return ::NS(Buffer_get_num_of_garbage_ranges)( this->getCApiPtr() );
+    }
+
+    SIXTRL_INLINE Buffer::size_type
+    Buffer::getMaxNumGarbageRanges() const SIXTRL_NOEXCEPT
+    {
+        return ::NS(Buffer_get_max_num_of_garbage_ranges)( this->getCApiPtr() );
+    }
+
+    SIXTRL_INLINE Buffer::size_type
+    Buffer::getGarbageRangesSize() const SIXTRL_NOEXCEPT
+    {
+        return ::NS(Buffer_get_garbage_size)( this->getCApiPtr() );
+    }
+
     /* ----------------------------------------------------------------- */
 
     SIXTRL_INLINE Buffer::address_t
@@ -767,6 +849,34 @@ namespace SIXTRL_NAMESPACE
             reinterpret_cast< ptr_const_size_t >( sizes   ),
             reinterpret_cast< ptr_const_size_t >( counts  ) );
     }
+
+    #if !defined( _GPUCODE )
+    SIXTRL_HOST_FN SIXTRL_INLINE Buffer::size_type
+    Buffer::GetBinaryFileSize( char const* path_to_file ) SIXTRL_NOEXCEPT
+    {
+        using size_t = Buffer::size_type;
+
+        size_t file_size = size_t{ 0 };
+        FILE* fp = std::fopen( path_to_file, "rb" );
+
+        if( fp != nullptr )
+        {
+            long length = long{ 0u };
+
+            std::fseek( fp, 0, SEEK_END );
+            length = std::ftell( fp );
+            std::fclose( fp );
+            fp = nullptr;
+
+            if( length > long{ 0 } )
+            {
+                file_size = static_cast< size_t >( length );
+            }
+        }
+
+        return file_size;
+    }
+    #endif /* !defined( _GPUCODE ) */
 
     SIXTRL_INLINE bool Buffer::allocateDataStore(
         Buffer::size_type const buffer_capacity, Buffer::flags_t const flags )

--- a/sixtracklib/common/impl/buffer_type.h
+++ b/sixtracklib/common/impl/buffer_type.h
@@ -107,6 +107,10 @@ NS(object_type_values_t);
     #define   SIXTRL_BUFFER_DEFAULT_HEADER_SIZE             64u
 #endif /* !defined( SIXTRL_BUFFER_DEFAULT_HEADER_SIZE ) */
 
+#if !defined( SIXTRL_BUFFER_MINIMAL_LENGTH)
+    #define SIXTRL_BUFFER_MINIMAL_LENGTH                   128u
+#endif /* !defined( SIXTRL_BUFFER_MINIMAL_LENGTH) */
+
 #if !defined( _GPUCODE )
 
 /* ------------------------------------------------------------------------- */
@@ -157,6 +161,9 @@ SIXTRL_STATIC_VAR NS(buffer_size_t)  const NS(BUFFER_DEFAULT_SLOT_SIZE) =
 
 SIXTRL_STATIC_VAR NS(buffer_size_t) const NS(BUFFER_DEFAULT_HEADER_SIZE) =
     ( NS(buffer_size_t) )SIXTRL_BUFFER_DEFAULT_HEADER_SIZE;
+
+SIXTRL_STATIC_VAR NS(buffer_size_t) const NS(BUFFER_MINIMAL_LENGTH) =
+    ( NS(buffer_size_t) )SIXTRL_BUFFER_MINIMAL_LENGTH;
 
 /* ------------------------------------------------------------------------- */
 
@@ -320,6 +327,10 @@ namespace SIXTRL_NAMESPACE
     SIXTRL_STATIC_VAR SIXTRL_CONSTEXPR_OR_CONST buffer_size_t
         BUFFER_DEFAULT_HEADER_SIZE = static_cast< buffer_flags_t >(
             SIXTRL_BUFFER_DEFAULT_HEADER_SIZE );
+
+    SIXTRL_STATIC_VAR SIXTRL_CONSTEXPR_OR_CONST buffer_size_t
+        BUFFER_MINIMAL_LENGTH = static_cast< buffer_size_t >(
+            SIXTRL_BUFFER_MINIMAL_LENGTH );
 }
 
 #endif /* defined( __cplusplus ) */

--- a/sixtracklib/common/particles.h
+++ b/sixtracklib/common/particles.h
@@ -4046,25 +4046,30 @@ SIXTRL_INLINE void NS(Particles_set_energy_value)(
 {
     typedef NS(particle_real_t) real_t;
 
-    SIXTRL_STATIC_VAR real_t const ONE = ( real_t )1;
+    real_t const beta0       = NS(Particles_get_beta0_value)( p, index );
+    real_t const p0c         = NS(Particles_get_p0c_value)( p, index );
 
-    real_t const beta0          = NS(Particles_get_beta0_value)( p, index );
-    real_t const p0c            = NS(Particles_get_p0c_value)( p, index );
+    real_t const ptau_beta0  = ( beta0 * energy ) / p0c;
+    real_t const beta0_squ   = beta0 * beta0;
+    real_t const beta0_plus_delta_beta0 = sqrt(
+        ptau_beta0 * ptau_beta0 + ( real_t )2 * ptau_beta0 + beta0_squ );
 
-    real_t const ptau           = energy / p0c;
-    real_t const psigma         = ptau / beta0;
-    real_t const one_plus_delta = sqrt( ptau * ptau + ( real_t )2 * psigma + ONE );
-    real_t const delta          = one_plus_delta - ONE;
-    real_t const beta           = one_plus_delta / ( ONE / beta0 + ptau );
-    real_t const rpp            = ONE  / one_plus_delta;
-    real_t const rvv            = beta / beta0;
+    real_t const psigma = ptau_beta0 / beta0_squ;
+    real_t const delta  = ( beta0_plus_delta_beta0 - beta0 ) / beta0;
+    real_t const rpp    = beta0 / beta0_plus_delta_beta0;
+    real_t const rvv    = ( beta0_plus_delta_beta0 ) /
+                          ( beta0 + ptau_beta0 * beta0 );
 
-    SIXTRL_ASSERT( index < NS(Particles_get_num_of_particles)( p ) );
+    SIXTRL_ASSERT( beta0     > ( real_t )0 );
+    SIXTRL_ASSERT( p0c       > ( real_t )0 );
+    SIXTRL_ASSERT( beta0_squ > ( real_t )0 );
+    SIXTRL_ASSERT( ( ptau_beta0 * ptau_beta0 +
+        ( real_t )2 * ptau_beta0 + beta0_squ ) > ( real_t )0 );
 
+    NS(Particles_set_delta_value)(  p, index, delta  );
+    NS(Particles_set_rpp_value)(    p, index, rpp    );
+    NS(Particles_set_rvv_value)(    p, index, rvv    );
     NS(Particles_set_psigma_value)( p, index, psigma );
-    NS(Particles_set_delta_value)(  p, index, delta );
-    NS(Particles_set_rpp_value)( p, index, rpp );
-    NS(Particles_set_rvv_value)( p, index, rvv );
 
     return;
 }

--- a/sixtracklib/common/particles.h
+++ b/sixtracklib/common/particles.h
@@ -470,6 +470,21 @@ SIXTRL_FN SIXTRL_STATIC void NS(Particles_assign_ptr_to_s)(
     SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles,
     NS(particle_real_ptr_t) ptr_to_ss );
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_s_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const s_diff_value );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_s_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT s_diff_values );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_s)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const s_diff_value );
+
 /* ------------------------------------------------------------------------- */
 
 SIXTRL_FN SIXTRL_STATIC NS(particle_real_t) NS(Particles_get_x_value)(
@@ -496,6 +511,21 @@ SIXTRL_FN SIXTRL_STATIC void NS(Particles_assign_ptr_to_x)(
     SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles,
     NS(particle_real_ptr_t) ptr_to_xs );
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_x_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const s_diff_value );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_x_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT s_diff_values );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_x)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const s_diff_value );
+
 /* ------------------------------------------------------------------------- */
 
 SIXTRL_FN SIXTRL_STATIC NS(particle_real_t) NS(Particles_get_y_value)(
@@ -520,6 +550,21 @@ SIXTRL_FN SIXTRL_STATIC void NS(Particles_set_y_value)(
 SIXTRL_FN SIXTRL_STATIC void NS(Particles_assign_ptr_to_y)(
     SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles,
     NS(particle_real_ptr_t) ptr_to_ys );
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_y_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const y_diff_value );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_y_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT y_diff_values );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_y)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const y_diff_value );
 
 /* ------------------------------------------------------------------------- */
 
@@ -547,6 +592,21 @@ SIXTRL_FN SIXTRL_STATIC void NS(Particles_assign_ptr_to_px)(
     SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles,
     NS(particle_real_ptr_t) ptr_to_pxs );
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_px_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const px_diff_value );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_px_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT px_diff_values );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_px)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const px_diff_value );
+
 /* ------------------------------------------------------------------------- */
 
 SIXTRL_FN SIXTRL_STATIC NS(particle_real_t) NS(Particles_get_py_value)(
@@ -572,6 +632,21 @@ SIXTRL_FN SIXTRL_STATIC void NS(Particles_set_py_value)(
 SIXTRL_FN SIXTRL_STATIC void NS(Particles_assign_ptr_to_py)(
     SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles,
     NS(particle_real_ptr_t) ptr_to_pys );
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_py_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const py_diff_value );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_py_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT py_diff_values );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_py)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const py_diff_value );
 
 /* ------------------------------------------------------------------------- */
 
@@ -600,6 +675,21 @@ SIXTRL_FN SIXTRL_STATIC void NS(Particles_assign_ptr_to_zeta)(
     SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles,
     NS(particle_real_ptr_t) ptr_to_zetas );
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_zeta_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const zeta_diff_value );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_zeta_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT zeta_diff_values );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_zeta)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const zeta_diff_value );
+
 /* ------------------------------------------------------------------------- */
 
 SIXTRL_FN SIXTRL_STATIC SIXTRL_REAL_T NS(Particles_get_psigma_value)(
@@ -625,6 +715,21 @@ SIXTRL_FN SIXTRL_STATIC void NS(Particles_set_psigma_value)(
 SIXTRL_FN SIXTRL_STATIC void NS(Particles_assign_ptr_to_psigma)(
     SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles,
     NS(particle_real_ptr_t) ptr_to_psigmas );
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_psigma_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const psigma_diff_value );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_psigma_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT psigma_diff_values );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_psigma)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const psigma_diff_value );
 
 /* ------------------------------------------------------------------------- */
 
@@ -679,6 +784,37 @@ SIXTRL_FN SIXTRL_STATIC void NS(Particles_set_delta_value)(
 SIXTRL_FN SIXTRL_STATIC void NS(Particles_assign_ptr_to_delta)(
     SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles,
     NS(particle_real_ptr_t) ptr_to_deltas );
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_delta_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const delta_diff_value );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_delta_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT delta_diff_values );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_add_to_delta)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const delta_diff_value );
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_update_delta_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT p,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const new_delta_value );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_update_delta_value_increment)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT p,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const delta_value_diff );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_update_delta)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT p,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT ptr_to_deltas );
 
 /* ------------------------------------------------------------------------- */
 
@@ -3111,6 +3247,59 @@ SIXTRL_INLINE void NS(Particles_assign_ptr_to_s)(
     return;
 }
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_INLINE void NS(Particles_add_to_s_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const s_diff_value )
+{
+    SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( particles->s != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( index < NS(Particles_get_num_of_particles)( particles ) );
+
+    particles->s[ index ] += s_diff_value;
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_s_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT s_diff_values )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    SIXTRL_ASSERT( s_diff_values != SIXTRL_NULLPTR );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_s_value)( particles, ii, s_diff_values[ ii ] );
+    }
+
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_s)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const s_diff_value )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_s_value)( particles, ii, s_diff_value );
+    }
+
+    return;
+}
+
 /* ------------------------------------------------------------------------- */
 
 SIXTRL_INLINE NS(particle_real_t) NS(Particles_get_x_value)(
@@ -3175,6 +3364,59 @@ SIXTRL_INLINE void NS(Particles_assign_ptr_to_x)(
 {
     SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
     particles->x = ptr_to_xs;
+    return;
+}
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_INLINE void NS(Particles_add_to_x_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const x_diff_value )
+{
+    SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( particles->x != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( index < NS(Particles_get_num_of_particles)( particles ) );
+
+    particles->x[ index ] += x_diff_value;
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_x_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT x_diff_values )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    SIXTRL_ASSERT( x_diff_values != SIXTRL_NULLPTR );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_x_value)( particles, ii, x_diff_values[ ii ] );
+    }
+
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_x)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const x_diff_value )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_x_value)( particles, ii, x_diff_value );
+    }
+
     return;
 }
 
@@ -3245,6 +3487,59 @@ SIXTRL_INLINE void NS(Particles_assign_ptr_to_y)(
     return;
 }
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_INLINE void NS(Particles_add_to_y_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const y_diff_value )
+{
+    SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( particles->y != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( index < NS(Particles_get_num_of_particles)( particles ) );
+
+    particles->y[ index ] += y_diff_value;
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_y_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT y_diff_values )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    SIXTRL_ASSERT( y_diff_values != SIXTRL_NULLPTR );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_y_value)( particles, ii, y_diff_values[ ii ] );
+    }
+
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_y)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const y_diff_value )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_y_value)( particles, ii, y_diff_value );
+    }
+
+    return;
+}
+
 /* ------------------------------------------------------------------------- */
 
 SIXTRL_INLINE NS(particle_real_t) NS(Particles_get_px_value)(
@@ -3309,6 +3604,59 @@ SIXTRL_INLINE void NS(Particles_assign_ptr_to_px)(
 {
     SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
     particles->px = ptr_to_pxs;
+    return;
+}
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_INLINE void NS(Particles_add_to_px_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const px_diff_value )
+{
+    SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( particles->px != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( index < NS(Particles_get_num_of_particles)( particles ) );
+
+    particles->px[ index ] += px_diff_value;
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_px_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT px_diff_values )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    SIXTRL_ASSERT( px_diff_values != SIXTRL_NULLPTR );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_px_value)( particles, ii, px_diff_values[ ii ] );
+    }
+
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_px)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const px_diff_value )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_px_value)( particles, ii, px_diff_value );
+    }
+
     return;
 }
 
@@ -3379,6 +3727,59 @@ SIXTRL_INLINE void NS(Particles_assign_ptr_to_py)(
     return;
 }
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_INLINE void NS(Particles_add_to_py_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const py_diff_value )
+{
+    SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( particles->py != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( index < NS(Particles_get_num_of_particles)( particles ) );
+
+    particles->py[ index ] += py_diff_value;
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_py_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT py_diff_values )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    SIXTRL_ASSERT( py_diff_values != SIXTRL_NULLPTR );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_py_value)( particles, ii, py_diff_values[ ii ] );
+    }
+
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_py)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const py_diff_value )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_py_value)( particles, ii, py_diff_value );
+    }
+
+    return;
+}
+
 /* ------------------------------------------------------------------------- */
 
 SIXTRL_INLINE NS(particle_real_t) NS(Particles_get_zeta_value)(
@@ -3446,6 +3847,60 @@ SIXTRL_INLINE void NS(Particles_assign_ptr_to_zeta)(
     return;
 }
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_INLINE void NS(Particles_add_to_zeta_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const zeta_diff_value )
+{
+    SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( particles->zeta != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( index < NS(Particles_get_num_of_particles)( particles ) );
+
+    particles->zeta[ index ] += zeta_diff_value;
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_zeta_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT zeta_diff_values )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    SIXTRL_ASSERT( zeta_diff_values != SIXTRL_NULLPTR );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_zeta_value)( particles, ii,
+                                         zeta_diff_values[ ii ] );
+    }
+
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_zeta)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const zeta_diff_value )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_zeta_value)( particles, ii, zeta_diff_value );
+    }
+
+    return;
+}
+
 /* ------------------------------------------------------------------------- */
 
 SIXTRL_INLINE NS(particle_real_t) NS(Particles_get_psigma_value)(
@@ -3510,6 +3965,60 @@ SIXTRL_INLINE void NS(Particles_assign_ptr_to_psigma)(
 {
     SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
     particles->psigma = ptr_to_psigmas;
+    return;
+}
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_INLINE void NS(Particles_add_to_psigma_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const psigma_diff_value )
+{
+    SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( particles->psigma != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( index < NS(Particles_get_num_of_particles)( particles ) );
+
+    particles->psigma[ index ] += psigma_diff_value;
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_psigma_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT psigma_diff_values )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    SIXTRL_ASSERT( psigma_diff_values != SIXTRL_NULLPTR );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_psigma_value)(
+            particles, ii, psigma_diff_values[ ii ] );
+    }
+
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_psigma)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const psigma_diff_value )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_psigma_value)( particles, ii, psigma_diff_value );
+    }
+
     return;
 }
 
@@ -3692,6 +4201,139 @@ SIXTRL_INLINE void NS(Particles_assign_ptr_to_delta)(
 {
     SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
     particles->delta = ptr_to_deltas;
+    return;
+}
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_INLINE void NS(Particles_add_to_delta_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const delta_diff_value )
+{
+    SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( particles->delta != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( index < NS(Particles_get_num_of_particles)( particles ) );
+
+    particles->delta[ index ] += delta_diff_value;
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_delta_detailed)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT delta_diff_values )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    SIXTRL_ASSERT( delta_diff_values != SIXTRL_NULLPTR );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_delta_value)(
+            particles, ii, delta_diff_values[ ii ] );
+    }
+
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_add_to_delta)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
+    NS(particle_real_t) const delta_diff_value )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_add_to_delta_value)(
+            particles, ii, delta_diff_value );
+    }
+
+    return;
+}
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_INLINE void NS(Particles_update_delta_value)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT p,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const new_delta_value )
+{
+    typedef NS(particle_real_t) real_t;
+
+    SIXTRL_STATIC_VAR real_t const ONE = ( real_t )1;
+
+    real_t const beta0               = NS(Particles_get_beta0_value)( p, index );
+    real_t const inv_beta0           = ONE / beta0;
+    real_t const inv_beta0_squ       = inv_beta0 * inv_beta0;
+    real_t const one_plus_delta      = ONE + new_delta_value;
+    real_t const inv_beta0_plus_ptau = sqrt( new_delta_value * new_delta_value +
+        ( real_t )2 * new_delta_value + inv_beta0_squ );
+
+    // beta = ( 1 + delta ) / ( 1/beta0 + ptau ) ==
+    //        ( 1 + delta ) / ( sqrt( ... ) - 1/beta0 + 1/beta0 )  ==
+    //        ( 1 + delta ) / sqrt( delta^2 + 2 * delta + (1/beta0)^2 )
+    real_t const beta   = one_plus_delta / inv_beta0_plus_ptau;
+
+    // rvv = beta / beta0
+    real_t const rvv    = beta * inv_beta0;
+
+    // psigma = ptau / beta0 == ( 1/beta0 ) * sqrt( ... ) - (1/beta0)^2
+    real_t const psigma = inv_beta0 * inv_beta0_plus_ptau - inv_beta0_squ;
+
+    // rpp = 1 / ( 1 + delta )
+    real_t const rpp = 1 / ( 1 + new_delta_value );
+
+    SIXTRL_ASSERT( beta0 > ( real_t )0 );
+    SIXTRL_ASSERT( ( ONE + new_delta_value ) > ( real_t )0 );
+    SIXTRL_ASSERT( ( new_delta_value * new_delta_value + ( real_t )2 *
+        new_delta_value + inv_beta0 * inv_beta0 ) > ( real_t )0 );
+
+    NS(Particles_set_delta_value)(  p, index, new_delta_value );
+    NS(Particles_set_psigma_value)( p, index, psigma );
+    NS(Particles_set_rpp_value)(    p, index, rpp );
+    NS(Particles_set_rvv_value)(    p, index, rvv );
+
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_update_delta_value_increment)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT p,
+    NS(particle_num_elements_t) const index,
+    NS(particle_real_t) const delta_value_diff )
+{
+    typedef NS(particle_real_t) real_t;
+
+    real_t const current_delta = NS(Particles_get_delta_value)( p, index );
+    real_t const new_delta     = current_delta + delta_value_diff;
+
+    NS(Particles_update_delta_value)( p, index, new_delta );
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_update_delta)(
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT p,
+    NS(particle_real_const_ptr_t) SIXTRL_RESTRICT ptr_to_deltas )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0;
+    num_elem_t const num_particles = NS(Particles_get_num_of_particles)( p );
+
+    SIXTRL_ASSERT( ptr_to_deltas != SIXTRL_NULLPTR );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_update_delta_value)( p, ii, ptr_to_deltas[ ii ] );
+    }
+
     return;
 }
 

--- a/sixtracklib/opencl/internal/argument.cpp
+++ b/sixtracklib/opencl/internal/argument.cpp
@@ -57,6 +57,8 @@ namespace SIXTRL_NAMESPACE
             this->m_cl_buffer = cl::Buffer(
                 *ptr_ocl_ctx, CL_MEM_READ_WRITE, arg_size, nullptr );
 
+            this->m_arg_size = arg_size;
+
             this->m_cl_success_flag = cl::Buffer(
                 *ptr_ocl_ctx, CL_MEM_READ_WRITE, sizeof( int32_t ), nullptr );
 
@@ -90,6 +92,8 @@ namespace SIXTRL_NAMESPACE
         {
             this->m_cl_buffer = cl::Buffer(
                 *ptr_ocl_ctx, CL_MEM_READ_WRITE, arg_size, nullptr );
+
+            this->m_arg_size = arg_size;
 
             this->m_cl_success_flag = cl::Buffer(
                 *ptr_ocl_ctx, CL_MEM_READ_WRITE, sizeof( int32_t ), nullptr );
@@ -125,6 +129,8 @@ namespace SIXTRL_NAMESPACE
             this->m_cl_buffer = cl::Buffer(
                 *ptr_ocl_ctx, CL_MEM_READ_WRITE, arg_size, nullptr );
 
+            this->m_arg_size = arg_size;
+
             this->m_cl_success_flag = cl::Buffer(
                 *ptr_ocl_ctx, CL_MEM_READ_WRITE, sizeof( int32_t ), nullptr );
 
@@ -156,6 +162,8 @@ namespace SIXTRL_NAMESPACE
         {
             this->m_cl_buffer = cl::Buffer(
                 *ptr_ocl_ctx, CL_MEM_READ_WRITE, arg_size, nullptr );
+
+            this->m_arg_size = arg_size;
 
             this->m_cl_success_flag = cl::Buffer(
                 *ptr_ocl_ctx, CL_MEM_READ_WRITE, sizeof( int32_t ), nullptr );

--- a/sixtracklib/opencl/internal/context.cpp
+++ b/sixtracklib/opencl/internal/context.cpp
@@ -141,7 +141,7 @@ namespace SIXTRL_NAMESPACE
               this->numAvailableKernels() ) )
         {
             program_id_t const tracking_program_id =
-                this->kernelProgramId( kernel_id );
+                this->programIdByKernelId( kernel_id );
 
             if( ( tracking_program_id >= program_id_t{ 0 } ) &&
                 ( static_cast< size_type >( tracking_program_id ) <

--- a/tests/sixtracklib/opencl/CMakeLists.txt
+++ b/tests/sixtracklib/opencl/CMakeLists.txt
@@ -2,55 +2,93 @@
 
 if( GTEST_FOUND )
 
-    set(   UNIT_TEST_TARGETS )
+    set(   C99_UNIT_TEST_TARGETS )
+    set(   CXX_UNIT_TEST_TARGETS )
+
     set(   SIXTRACKL_TEST_LIBRARIES ${SIXTRACKL_TEST_LIBRARIES}
          ${SIXTRACKL_GTEST_LIBRARIES} sixtrack_test sixtrack m dl )
+
+    # --------------------------------------------------------------------------
+    # test_context_opencl_c99:
+
+    add_executable( test_context_opencl_c99 test_context_opencl_c99.cpp )
+    set( C99_UNIT_TEST_TARGETS ${C99_UNIT_TEST_TARGETS} test_context_opencl_c99 )
+    add_test( C99_OpenCL_ContextTests test_context_opencl_c99 )
+
+    # --------------------------------------------------------------------------
+    # test_context_opencl_cxx:
+
+    add_executable( test_context_opencl_cxx test_context_opencl_cxx.cpp )
+    set( CXX_UNIT_TEST_TARGETS ${CXX_UNIT_TEST_TARGETS} test_context_opencl_cxx )
+    add_test( CXX_OpenCL_ContextTests test_context_opencl_cxx )
 
     # --------------------------------------------------------------------------
     # test_buffer_opencl_c99:
 
     add_executable( test_buffer_opencl_c99 test_buffer_opencl_c99.cpp )
-    set( UNIT_TEST_TARGETS ${UNIT_TEST_TARGETS} test_buffer_opencl_c99 )
+    set( C99_UNIT_TEST_TARGETS ${C99_UNIT_TEST_TARGETS} test_buffer_opencl_c99 )
     add_test( C99_OpenCL_BufferTests test_buffer_opencl_c99 )
 
     # --------------------------------------------------------------------------
     # test_particles_opencl_c99:
 
     add_executable( test_particles_opencl_c99 test_particles_opencl_c99.cpp )
-    set( UNIT_TEST_TARGETS ${UNIT_TEST_TARGETS} test_particles_opencl_c99 )
+    set( C99_UNIT_TEST_TARGETS ${C99_UNIT_TEST_TARGETS} test_particles_opencl_c99 )
     add_test( C99_OpenCL_ParticleBufferTests test_particles_opencl_c99 )
 
     # --------------------------------------------------------------------------
     # test_be_drift_opencl_c99:
 
     add_executable( test_be_drift_opencl_c99 test_be_drift_opencl_c99.cpp )
-    set( UNIT_TEST_TARGETS ${UNIT_TEST_TARGETS} test_be_drift_opencl_c99 )
+    set( C99_UNIT_TEST_TARGETS ${C99_UNIT_TEST_TARGETS} test_be_drift_opencl_c99 )
     add_test( C99_OpenCL_BeamElementsDriftTests test_be_drift_opencl_c99 )
 
     # --------------------------------------------------------------------------
     # test_track_opencl_c99:
 
     add_executable( test_track_opencl_c99 test_track_opencl_c99.cpp )
-    set( UNIT_TEST_TARGETS ${UNIT_TEST_TARGETS} test_track_opencl_c99 )
+    set( C99_UNIT_TEST_TARGETS ${C99_UNIT_TEST_TARGETS} test_track_opencl_c99 )
     add_test( C99_OpenCL_TrackParticlesTests test_track_opencl_c99 )
 
     # *************************************************************************
     # Set all properties:
 
-    set_property( TARGET ${UNIT_TEST_TARGETS}
-                  PROPERTY LINK_LIBRARIES ${SIXTRACKL_TEST_LIBRARIES} )
+    if( C99_UNIT_TEST_TARGETS )
 
-    set_property(
-        TARGET ${UNIT_TEST_TARGETS}
-        APPEND PROPERTY INCLUDE_DIRECTORIES
-        "${CMAKE_SOURCE_DIR}"
-        "${CMAKE_SOURCE_DIR}/tests"
-        $<BUILD_INTERFACE:${SIXTRACKL_GTEST_INCLUDE_DIRS}>
-    )
+        set_property( TARGET ${C99_UNIT_TEST_TARGETS}
+                      PROPERTY LINK_LIBRARIES ${SIXTRACKL_TEST_LIBRARIES} )
 
-    set_property( TARGET ${UNIT_TEST_TARGETS} PROPERTY CXX_STANDARD 11 )
-    set_property( TARGET ${UNIT_TEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON )
-    set_property( TARGET ${UNIT_TEST_TARGETS} PROPERTY COMPILE_OPTIONS
-                  ${SIXTRACKLIB_CPU_FLAGS} -Wall -Werror -pedantic )
+        set_property(
+            TARGET ${C99_UNIT_TEST_TARGETS}
+            APPEND PROPERTY INCLUDE_DIRECTORIES
+            "${CMAKE_SOURCE_DIR}"
+            "${CMAKE_SOURCE_DIR}/tests"
+            $<BUILD_INTERFACE:${SIXTRACKL_GTEST_INCLUDE_DIRS}>
+        )
+
+        set_property( TARGET ${C99_UNIT_TEST_TARGETS} PROPERTY CXX_STANDARD 11 )
+        set_property( TARGET ${C99_UNIT_TEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON )
+        set_property( TARGET ${C99_UNIT_TEST_TARGETS} PROPERTY COMPILE_OPTIONS
+                      ${SIXTRACKLIB_CPU_FLAGS} -Wall -Werror -pedantic )
+    endif()
+
+    if( CXX_UNIT_TEST_TARGETS )
+
+        set_property( TARGET ${CXX_UNIT_TEST_TARGETS}
+                      PROPERTY LINK_LIBRARIES ${SIXTRACKL_TEST_LIBRARIES} )
+
+        set_property(
+            TARGET ${CXX_UNIT_TEST_TARGETS}
+            APPEND PROPERTY INCLUDE_DIRECTORIES
+            "${CMAKE_SOURCE_DIR}"
+            "${CMAKE_SOURCE_DIR}/tests"
+            $<BUILD_INTERFACE:${SIXTRACKL_GTEST_INCLUDE_DIRS}>
+        )
+
+        set_property( TARGET ${CXX_UNIT_TEST_TARGETS} PROPERTY CXX_STANDARD 11 )
+        set_property( TARGET ${CXX_UNIT_TEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON )
+        set_property( TARGET ${CXX_UNIT_TEST_TARGETS} PROPERTY COMPILE_OPTIONS
+                      ${SIXTRACKLIB_CPU_FLAGS} -Wall -Werror -pedantic )
+    endif()
 
 endif()

--- a/tests/sixtracklib/opencl/test_context_opencl_c99.cpp
+++ b/tests/sixtracklib/opencl/test_context_opencl_c99.cpp
@@ -1,0 +1,340 @@
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+#include <iterator>
+#include <sstream>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "sixtracklib/testlib.h"
+
+#include "sixtracklib/_impl/definitions.h"
+#include "sixtracklib/_impl/path.h"
+#include "sixtracklib/common/buffer.h"
+#include "sixtracklib/opencl/internal/base_context.h"
+#include "sixtracklib/opencl/context.h"
+#include "sixtracklib/opencl/argument.h"
+
+TEST( C99_OpenCL_Context, BaseOpenCLContext )
+{
+    using context_t     = ::st_ClContextBase;
+    using con_size_t    = ::st_context_size_t;
+    using node_id_t     = ::st_context_node_id_t;
+    using node_info_t   = ::st_context_node_info_t;
+    using kernel_id_t   = int;
+    using program_id_t  = int;
+    using argument_t    = ::st_ClArgument;
+
+    context_t* context = ::st_ClContextBase_create();
+
+    con_size_t const num_nodes =
+        ::st_ClContextBase_get_num_available_nodes( context );
+
+    ASSERT_TRUE( context != nullptr );
+
+    if( num_nodes > 0u )
+    {
+        node_info_t const* node_info_it  =
+            ::st_ClContextBase_get_available_nodes_info_begin( context );
+
+        node_info_t const* node_info_end =
+            ::st_ClContextBase_get_available_nodes_info_end( context );
+
+        ASSERT_TRUE( std::distance( node_info_it, node_info_end ) ==
+                     static_cast< std::ptrdiff_t >( num_nodes ) );
+
+        node_id_t const default_node_id =
+            NS(ClContextBase_get_default_node_id)( context );
+
+        ASSERT_TRUE( ::st_ComputeNodeId_is_valid( &default_node_id ) );
+
+        for( ; node_info_it != node_info_end ; ++node_info_it )
+        {
+            char default_str[ 16 ];
+            char node_id_str[ 16 ];
+
+            std::memset( &default_str[ 0 ], ( int )'\0', 16 );
+            std::memset( &node_id_str[ 0 ], ( int )'\0', 16 );
+
+            node_id_t const node_id = st_ComputeNodeInfo_get_id( node_info_it );
+            ASSERT_TRUE( ::st_ComputeNodeId_is_valid( &node_id ) );
+
+            ASSERT_TRUE( 0 == ::st_ComputeNodeId_to_string(
+                &node_id, &node_id_str[ 0 ], 16 ) );
+
+            if( ::st_ClContextBase_is_node_id_default_node( context, &node_id ) )
+            {
+                strncpy( &default_str[ 0 ], " [DEFAULT]", 16 );
+            }
+
+            ASSERT_TRUE( ::st_ComputeNodeInfo_get_arch( node_info_it ) != nullptr );
+            ASSERT_TRUE( ::st_ComputeNodeInfo_get_name( node_info_it ) != nullptr );
+            ASSERT_TRUE( ::st_ComputeNodeInfo_get_platform( node_info_it ) != nullptr );
+            ASSERT_TRUE( ::st_ComputeNodeInfo_get_description( node_info_it ) != nullptr );
+
+            std::cout << "INFO  ::    Device Id = "
+                      << node_id_str << default_str
+                      << "\r\n         Architecture = "
+                      << ::st_ComputeNodeInfo_get_arch( node_info_it )
+                      << "\r\n             Platform = "
+                      << ::st_ComputeNodeInfo_get_platform( node_info_it )
+                      << "\r\n          Device Name = "
+                      << ::st_ComputeNodeInfo_get_name( node_info_it )
+                      << "\r\n          Description = "
+                      << ::st_ComputeNodeInfo_get_description( node_info_it )
+                      << "\r\n"
+                      << std::endl;
+
+            /* ------------------------------------------------------------- */
+            /* Verify that the context has a remapping program but not a
+             * remapping kernel before device selection */
+
+            ASSERT_TRUE( !::st_ClContextBase_has_selected_node( context ) );
+            ASSERT_TRUE(  ::st_ClContextBase_has_remapping_program( context ) );
+
+            con_size_t const initial_num_programs =
+                ::st_ClContextBase_get_num_available_programs( context );
+
+            program_id_t remap_program_id =
+                ::st_ClContextBase_get_remapping_program_id( context );
+
+            ASSERT_TRUE( initial_num_programs >= con_size_t{ 0 } );
+
+            ASSERT_TRUE(  ::st_ClContextBase_get_num_available_kernels(
+                context ) == con_size_t{ 0 } );
+
+            ASSERT_TRUE(  ::st_ClContextBase_get_remapping_program_id(
+                context ) != -1 );
+
+            ASSERT_TRUE( !::st_ClContextBase_has_remapping_kernel( context ) );
+            ASSERT_TRUE(  ::st_ClContextBase_get_remapping_kernel_id(
+                context ) == -1 );
+
+            /* ------------------------------------------------------------- */
+            /* Select current node by node_id */
+
+            ASSERT_TRUE( ::st_ClContextBase_select_node_by_node_id(
+                context, &node_id ) );
+
+            ASSERT_TRUE( ::st_ClContextBase_has_selected_node( context ) );
+            ASSERT_TRUE( ::st_ComputeNodeId_are_equal( &node_id,
+                ::st_ClContextBase_get_selected_node_id( context ) ) );
+
+            ASSERT_TRUE( ::st_ClContextBase_get_selected_node_info( context )
+                         == node_info_it );
+
+            ASSERT_TRUE( ::st_ClContextBase_get_num_available_programs(
+                context ) == initial_num_programs );
+
+            con_size_t const initial_num_kernels =
+                ::st_ClContextBase_get_num_available_kernels( context );
+
+            ASSERT_TRUE( initial_num_kernels >= initial_num_programs );
+
+            ASSERT_TRUE( ::st_ClContextBase_has_remapping_program( context ) );
+            ASSERT_TRUE( ::st_ClContextBase_get_remapping_program_id(
+                         context ) == remap_program_id );
+
+            ASSERT_TRUE( ::st_ClContextBase_has_remapping_kernel( context ) );
+
+            kernel_id_t const remap_kernel_id =
+                ::st_ClContextBase_get_remapping_kernel_id( context );
+
+            ASSERT_TRUE( remap_kernel_id != kernel_id_t{ -1 } );
+            ASSERT_TRUE( remap_program_id ==
+                ::st_ClContextBase_get_program_id_by_kernel_id(
+                    context, remap_kernel_id ) );
+
+            /* ------------------------------------------------------------- */
+            /* Create ClArgument from st::Buffer */
+
+            ::st_Buffer* orig_buffer = ::st_Buffer_new_from_file(
+                ::st_PATH_TO_TEST_GENERIC_OBJ_BUFFER_DATA );
+
+            ::st_Buffer* copy_buffer = ::st_Buffer_new_detailed(
+                ::st_Buffer_get_num_of_objects( orig_buffer ),
+                ::st_Buffer_get_num_of_slots( orig_buffer ),
+                ::st_Buffer_get_num_of_dataptrs( orig_buffer ),
+                ::st_Buffer_get_num_of_garbage_ranges( orig_buffer ),
+                ::st_Buffer_get_flags( orig_buffer ) );
+
+            argument_t* orig_arg = ::st_ClArgument_new_from_buffer(
+                orig_buffer, context );
+
+            SIXTRL_ASSERT( ::st_ClArgument_get_ptr_to_context( orig_arg ) ==
+                           context );
+
+            SIXTRL_ASSERT( orig_arg != nullptr );
+            SIXTRL_ASSERT( ::st_ClArgument_get_argument_size( orig_arg ) ==
+                           ::st_Buffer_get_size( orig_buffer ) );
+
+            SIXTRL_ASSERT( ::st_ClArgument_uses_cobj_buffer( orig_arg ) );
+            SIXTRL_ASSERT( ::st_ClArgument_get_ptr_cobj_buffer( orig_arg ) ==
+                           orig_buffer );
+
+            argument_t* copy_arg =
+                ::st_ClArgument_new_from_buffer( copy_buffer, context );
+
+            SIXTRL_ASSERT( ::st_ClArgument_get_ptr_to_context( copy_arg ) ==
+                           context );
+
+            SIXTRL_ASSERT( orig_arg != nullptr );
+            SIXTRL_ASSERT( ::st_ClArgument_get_argument_size( copy_arg ) ==
+                           ::st_Buffer_get_size( copy_buffer ) );
+
+            SIXTRL_ASSERT( ::st_ClArgument_uses_cobj_buffer( copy_arg ) );
+            SIXTRL_ASSERT( ::st_ClArgument_get_ptr_cobj_buffer( copy_arg ) ==
+                           copy_buffer );
+
+            /* ------------------------------------------------------------- */
+            /* Add copy generic obj buffer program */
+
+            char path_to_copy_kernel_program[ 1024 ];
+            std::memset( path_to_copy_kernel_program, ( int )'\0', 1024 );
+
+            std::strncpy( path_to_copy_kernel_program, ::st_PATH_TO_BASE_DIR,
+                          1023 );
+
+            std::strncat( path_to_copy_kernel_program,
+                          "tests/sixtracklib/opencl/",
+                          1023 - std::strlen( path_to_copy_kernel_program ) );
+
+            std::strncat( path_to_copy_kernel_program,
+                          "opencl_buffer_generic_obj_kernel.cl",
+                          1023 - std::strlen( path_to_copy_kernel_program ) );
+
+
+            char copy_program_compile_options[ 1024 ];
+            std::memset( copy_program_compile_options, ( int )'\0', 1024 );
+
+            std::strncpy( copy_program_compile_options, "-D_GPUCODE=1", 1024 );
+
+            std::strncat( copy_program_compile_options, " -D__NAMESPACE=st_",
+                          1023 - std::strlen( copy_program_compile_options ) );
+
+            std::strncat( copy_program_compile_options,
+                          " -DSIXTRL_BUFFER_ARGPTR_DEC=__private",
+                          1023 - std::strlen( copy_program_compile_options ) );
+
+            std::strncat( copy_program_compile_options,
+                          " -DSIXTRL_BUFFER_DATAPTR_DEC=__global",
+                          1023 - std::strlen( copy_program_compile_options ) );
+
+            std::strncat( copy_program_compile_options, " -I",
+                          1023 - std::strlen( copy_program_compile_options ) );
+
+            std::strncat( copy_program_compile_options, ::st_PATH_TO_BASE_DIR,
+                          1023 - std::strlen( copy_program_compile_options ) );
+
+            std::strncat( copy_program_compile_options, " -I",
+                          1023 - std::strlen( copy_program_compile_options ) );
+
+            std::strncat( copy_program_compile_options, ::st_PATH_TO_BASE_DIR,
+                          1023 - std::strlen( copy_program_compile_options ) );
+
+            std::strncat( copy_program_compile_options, "tests",
+                          1023 - std::strlen( copy_program_compile_options ) );
+
+
+            program_id_t copy_program_id = ::st_ClContextBase_add_program_file(
+                context, path_to_copy_kernel_program,
+                    copy_program_compile_options );
+
+            ASSERT_TRUE( copy_program_id != program_id_t{ -1 } );
+
+            ASSERT_TRUE( ::st_ClContextBase_get_num_available_programs(
+                context ) == ( initial_num_programs + con_size_t{ 1 } ) );
+
+            ASSERT_TRUE( copy_program_id != remap_program_id );
+
+            ASSERT_TRUE( ::st_ClContextBase_has_program_file_path(
+                context, copy_program_id ) );
+
+            ASSERT_TRUE( 0 == std::strcmp( path_to_copy_kernel_program,
+                ::st_ClContextBase_get_program_path_to_file(
+                    context, copy_program_id ) ) );
+
+            if( !::st_ClContextBase_is_program_compiled(
+                    context, copy_program_id ) )
+            {
+                std::cout << "ERROR :: unable to compile copy program -> "
+                          << "error report \r\n"
+                          << ::st_ClContextBase_get_program_compile_report(
+                              context, copy_program_id ) << std::endl;
+            }
+
+            ASSERT_TRUE( ::st_ClContextBase_is_program_compiled(
+                    context, copy_program_id ) );
+
+            ASSERT_TRUE( ::st_ClContextBase_get_num_available_kernels(
+                    context ) == initial_num_kernels );
+
+            kernel_id_t const copy_kernel_id = ::st_ClContextBase_enable_kernel(
+                context, "st_copy_orig_buffer", copy_program_id );
+
+            ASSERT_TRUE( copy_kernel_id != kernel_id_t{ -1 } );
+            ASSERT_TRUE( copy_kernel_id != remap_kernel_id );
+            ASSERT_TRUE( ::st_ClContextBase_get_num_available_kernels(
+                    context ) == ( initial_num_kernels + con_size_t{ 1 } ) );
+
+            ASSERT_TRUE( ::st_ClContextBase_get_program_id_by_kernel_id(
+                context, copy_kernel_id ) == copy_program_id );
+
+            ASSERT_TRUE( ::st_ClContextBase_find_kernel_id_by_name( context,
+                "st_copy_orig_buffer" ) == copy_kernel_id );
+
+            ASSERT_TRUE( ::st_ClContextBase_get_kernel_num_args(
+                context, copy_kernel_id ) == con_size_t{ 3u } );
+
+            /* ------------------------------------------------------------- */
+            /* clear context to prepare it for the next node, if available   */
+
+            ::st_ClContextBase_clear( context );
+
+            ASSERT_TRUE( !::st_ClContextBase_has_selected_node( context ) );
+
+            ASSERT_TRUE( !::st_ClContextBase_has_selected_node( context ) );
+            ASSERT_TRUE(  ::st_ClContextBase_get_num_available_programs(
+                context ) == initial_num_programs );
+
+            ASSERT_TRUE( ::st_ClContextBase_get_num_available_kernels(
+                context ) == con_size_t{ 0 } );
+
+            ASSERT_TRUE( ::st_ClContextBase_get_remapping_program_id(
+                context ) == remap_program_id );
+
+            ASSERT_TRUE( ::st_ClContextBase_get_remapping_kernel_id(
+                context ) == kernel_id_t{ -1 } );
+
+            /* ------------------------------------------------------------- */
+            /* Clean-up and ressource deallocation */
+
+            ::st_ClArgument_delete( orig_arg );
+            ::st_ClArgument_delete( copy_arg );
+
+            orig_arg = nullptr;
+            copy_arg = nullptr;
+
+            ::st_Buffer_delete( orig_buffer );
+            ::st_Buffer_delete( copy_buffer );
+
+            orig_buffer = nullptr;
+            copy_buffer = nullptr;
+        }
+    }
+    else
+    {
+        std::cout << "INFO  :: No suitable OpenCL platforms found -> "
+                  << "skipping unit-test"
+                  << std::endl;
+    }
+
+    ::st_ClContextBase_delete( context );
+}
+
+/* end: tests/sixtracklib/opencl/test_opencl_context_c99.cpp */

--- a/tests/sixtracklib/opencl/test_context_opencl_cxx.cpp
+++ b/tests/sixtracklib/opencl/test_context_opencl_cxx.cpp
@@ -1,0 +1,227 @@
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+#include <iterator>
+#include <sstream>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "sixtracklib/testlib.h"
+
+#include "sixtracklib/_impl/definitions.h"
+#include "sixtracklib/_impl/path.h"
+#include "sixtracklib/common/buffer.h"
+#include "sixtracklib/opencl/internal/base_context.h"
+#include "sixtracklib/opencl/context.h"
+#include "sixtracklib/opencl/argument.h"
+
+TEST( CXX_OpenCL_Context, BaseOpenCLContextClArgument )
+{
+    namespace st = sixtrack;
+
+    using context_t     = st::ClContextBase;
+    using con_size_t    = context_t::size_type;
+    using node_id_t     = context_t::node_id_t;
+    using kernel_id_t   = context_t::kernel_id_t;
+    using program_id_t  = context_t::program_id_t;
+    using cl_argument_t = st::ClArgument;
+
+    context_t context;
+    con_size_t const num_nodes = context.numAvailableNodes();
+
+    if( num_nodes > con_size_t{ 0 } )
+    {
+        auto node_info_it  = context.availableNodesInfoBegin();
+        auto node_info_end = context.availableNodesInfoEnd();
+
+        ASSERT_TRUE( std::distance( node_info_it, node_info_end ) ==
+                     static_cast< std::ptrdiff_t >( num_nodes ) );
+
+        node_id_t const default_node_id = context.defaultNodeId();
+
+        ASSERT_TRUE( ::st_ComputeNodeId_is_valid( &default_node_id ) );
+
+        for( ; node_info_it != node_info_end ; ++node_info_it )
+        {
+            char node_id_str[ 16 ];
+            std::memset( &node_id_str[ 0 ], ( int )'\0', 16 );
+
+            std::string default_str( "" );
+
+            node_id_t const node_id = ::st_ComputeNodeInfo_get_id( node_info_it );
+            ASSERT_TRUE( ::st_ComputeNodeId_is_valid( &node_id ) );
+
+            ASSERT_TRUE( 0 == ::st_ComputeNodeId_to_string(
+                &node_id, &node_id_str[ 0 ], 16 ) );
+
+            if( context.isDefaultNode( node_id ) )
+            {
+                default_str = " [DEFAULT]";
+            }
+
+            ASSERT_TRUE( ::st_ComputeNodeInfo_get_arch( node_info_it ) != nullptr );
+            ASSERT_TRUE( ::st_ComputeNodeInfo_get_name( node_info_it ) != nullptr );
+            ASSERT_TRUE( ::st_ComputeNodeInfo_get_platform( node_info_it ) != nullptr );
+            ASSERT_TRUE( ::st_ComputeNodeInfo_get_description( node_info_it ) != nullptr );
+
+            std::cout << "INFO  ::    Device Id = "
+                      << node_id_str << default_str
+                      << "\r\n         Architecture = "
+                      << ::st_ComputeNodeInfo_get_arch( node_info_it )
+                      << "\r\n             Platform = "
+                      << ::st_ComputeNodeInfo_get_platform( node_info_it )
+                      << "\r\n          Device Name = "
+                      << ::st_ComputeNodeInfo_get_name( node_info_it )
+                      << "\r\n          Description = "
+                      << ::st_ComputeNodeInfo_get_description( node_info_it )
+                      << "\r\n"
+                      << std::endl;
+
+            /* ------------------------------------------------------------- */
+            /* Verify that the context has a remapping program but not a
+             * remapping kernel before device selection */
+
+            ASSERT_TRUE( !context.hasSelectedNode() );
+
+            con_size_t const initial_num_programs =
+                context.numAvailablePrograms();
+
+            ASSERT_TRUE(  initial_num_programs > con_size_t{ 0 } );
+            ASSERT_TRUE(  context.numAvailableKernels() == con_size_t{ 0 } );
+
+            ASSERT_TRUE(  context.hasRemappingProgram() );
+
+            program_id_t const remap_program_id = context.remappingProgramId();
+            ASSERT_TRUE( remap_program_id >= program_id_t{ 0 } );
+
+            ASSERT_TRUE( !context.hasRemappingKernel() );
+            ASSERT_TRUE(  context.remappingKernelId() == kernel_id_t{ -1 } );
+
+            /* ------------------------------------------------------------- */
+            /* Select current node by node_id */
+
+            ASSERT_TRUE( context.selectNode( node_id ) );
+
+            ASSERT_TRUE( node_info_it == context.ptrSelectedNodeInfo() );
+            ASSERT_TRUE( ::st_ComputeNodeId_are_equal(
+                context.ptrSelectedNodeId(), &node_id ) );
+
+            ASSERT_TRUE( context.hasSelectedNode() );
+            ASSERT_TRUE( context.numAvailablePrograms() == initial_num_programs );
+            ASSERT_TRUE( context.numAvailableKernels()  >= initial_num_programs );
+
+            con_size_t const initial_num_kernels =
+                context.numAvailableKernels();
+
+            ASSERT_TRUE( context.hasRemappingProgram() );
+            ASSERT_TRUE( context.remappingProgramId() == remap_program_id );
+
+            ASSERT_TRUE( context.hasRemappingKernel() );
+
+            kernel_id_t const remap_kernel_id = context.remappingKernelId();
+            ASSERT_TRUE(  remap_kernel_id >= kernel_id_t{ 0 } );
+
+            ASSERT_TRUE( nullptr != context.openClKernel( remap_kernel_id ) );
+            ASSERT_TRUE( nullptr != context.openClProgram( remap_program_id ) );
+            ASSERT_TRUE( nullptr != context.openClContext() );
+            ASSERT_TRUE( nullptr != context.openClQueue() );
+
+            /* ------------------------------------------------------------- */
+            /* Create ClArgument from st::Buffer */
+
+            st::Buffer orig_buffer( ::st_PATH_TO_TEST_GENERIC_OBJ_BUFFER_DATA );
+
+            st::Buffer copy_buffer( orig_buffer.getNumObjects(),
+                                    orig_buffer.getNumSlots(),
+                                    orig_buffer.getNumDataptrs(),
+                                    orig_buffer.getNumGarbageRanges() );
+
+            cl_argument_t orig_arg( orig_buffer, &context );
+            cl_argument_t copy_arg( copy_buffer, &context );
+
+            /* ------------------------------------------------------------- */
+            /* Add copy generic obj buffer program */
+
+            std::string path_to_copy_kernel_program( ::st_PATH_TO_BASE_DIR );
+            path_to_copy_kernel_program += "tests/sixtracklib/opencl/";
+            path_to_copy_kernel_program += "opencl_buffer_generic_obj_kernel.cl";
+
+            std::string copy_program_compile_options = "-D_GPUCODE=1";
+            copy_program_compile_options += " -D__NAMESPACE=st_";
+            copy_program_compile_options += " -DSIXTRL_BUFFER_ARGPTR_DEC=__private";
+            copy_program_compile_options += " -DSIXTRL_BUFFER_DATAPTR_DEC=__global";
+            copy_program_compile_options += " -I";
+            copy_program_compile_options += NS(PATH_TO_BASE_DIR);
+            copy_program_compile_options += " -I";
+            copy_program_compile_options += NS(PATH_TO_BASE_DIR);
+            copy_program_compile_options += "tests";
+
+            program_id_t copy_program_id =
+                context.addProgramFile( path_to_copy_kernel_program,
+                                        copy_program_compile_options );
+
+            ASSERT_TRUE( copy_program_id != program_id_t{ -1 } );
+            ASSERT_TRUE( context.numAvailablePrograms() ==
+                ( initial_num_programs + con_size_t{ 1 } ) );
+
+            ASSERT_TRUE( copy_program_id != remap_program_id );
+            ASSERT_TRUE( context.programHasFilePath( copy_program_id ) );
+            ASSERT_TRUE( path_to_copy_kernel_program.compare(
+                context.programPathToFile( copy_program_id ) ) == 0 );
+
+            if( !context.isProgramCompiled( copy_program_id ) )
+            {
+                std::cout << "ERROR :: unable to compile copy program -> "
+                          << "error report \r\n"
+                          << context.programCompileReport( copy_program_id )
+                          << std::endl;
+            }
+
+            ASSERT_TRUE( context.isProgramCompiled( copy_program_id ) );
+            ASSERT_TRUE( context.numAvailableKernels() == initial_num_kernels );
+
+            kernel_id_t const copy_kernel_id = context.enableKernel(
+                "st_copy_orig_buffer", copy_program_id );
+
+            ASSERT_TRUE( copy_kernel_id != kernel_id_t{ -1 } );
+            ASSERT_TRUE( copy_kernel_id != context.remappingKernelId() );
+            ASSERT_TRUE( context.numAvailableKernels() ==
+                ( initial_num_kernels + con_size_t{ 1 } ) );
+
+            ASSERT_TRUE( context.programIdByKernelId( copy_kernel_id ) ==
+                         copy_program_id );
+
+            ASSERT_TRUE( context.findKernelByName( "st_copy_orig_buffer" ) ==
+                         copy_kernel_id );
+
+            ASSERT_TRUE( context.kernelNumArgs( copy_kernel_id ) ==
+                         con_size_t{ 3u } );
+
+            /* ------------------------------------------------------------- */
+            /* clear context to prepare it for the next node, if available   */
+
+            context.clear();
+            ASSERT_TRUE( !context.hasSelectedNode() );
+            ASSERT_TRUE(  context.numAvailablePrograms() == initial_num_programs );
+            ASSERT_TRUE(  context.numAvailableKernels()  == con_size_t{ 0 } );
+            ASSERT_TRUE(  context.remappingProgramId()   == remap_program_id );
+            ASSERT_TRUE(  context.remappingKernelId()    == kernel_id_t{ -1 } );
+
+            ASSERT_TRUE( nullptr == context.openClKernel( remap_kernel_id ) );
+            ASSERT_TRUE( nullptr == context.openClProgram( remap_program_id ) );
+        }
+    }
+    else
+    {
+        std::cout << "INFO  :: No suitable OpenCL platforms found -> "
+                  << "skipping unit-test"
+                  << std::endl;
+    }
+}
+
+/* end: tests/sixtracklib/opencl/test_opencl_context_c99.cpp */


### PR DESCRIPTION
- Please note the
     ```
   SIXTRL_INLINE void NS(Particles_update_delta_value)(
    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT p,
    NS(particle_num_elements_t) const index,
    NS(particle_real_t) const new_delta_value )
    ``` 
    function in sixtracklib/common/patricles.h, lines 4264 - 4305 . Updating delta via this function to a   
    new value also recalculates the values for psigma, rvv, and rpp,

- There are also now additional accessor functions that do not update the dependent parameters but     
  allow to increment a property in-place, potentially being faster and easier on the auto-vectorizer.      
  Please cf  
   ```
  void NS(Particles_add_to_x_value)(
      SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT particles,
      NS(particle_num_elements_t) const index,
      NS(particle_real_t) const x_diff_value );
  ```
  in lines 3372 - 3382 (and ff.) as an example. Maybe that's useful and saves some typing in your   
  tracking functions?
